### PR TITLE
Fix page reloading at root when using click event on anchor

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,5 +1,5 @@
 <p>
-  This is what I'm all about. <a href="" (click)="sendMeHome()"><strong>Take me back</strong></a>.
+  This is what I'm all about. <a href (click)="sendMeHome(); false"><strong>Take me back</strong></a>.
 </p>
 
 <ul>


### PR DESCRIPTION
This issue is [discussed in the course comments](https://coursetro.com/posts/code/111/Using-the-Angular-5-Router-(Tutorial)), as well as [several](https://stackoverflow.com/questions/14939385/href-overrides-ng-click-in-angular-js) [other](https://stackoverflow.com/questions/15622100/how-can-i-disable-href-if-onclick-is-executed) places, including the official Angular repo: [Empty href attribute navigates to the app base #7294](https://github.com/angular/angular/issues/7294).

Pending an official fix, and without changing the code entirely to use a [button styled as an anchor](http://jsfiddle.net/adardesign/5vHGc/), the fix in this patch seems the most elegant, and [comes from a comment](https://github.com/angular/angular/issues/7294#issuecomment-264068778) on that Angular repo issue, put forward by [simeyla](https://github.com/simeyla).